### PR TITLE
Avoid frequent std::vector allocations

### DIFF
--- a/include/mapbox/glyph_foundry_impl.hpp
+++ b/include/mapbox/glyph_foundry_impl.hpp
@@ -5,6 +5,7 @@
 #include <agg/agg_curves_impl.hpp>
 
 // boost
+#include <boost/container/small_vector.hpp>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/box.hpp>
@@ -187,7 +188,7 @@ namespace sdf_glyph_foundry
     {
         const int squared_radius = radius * radius;
 
-        std::vector<SegmentValue> results;
+        boost::container::small_vector<SegmentValue, 64> results;
         tree.query(bgi::intersects(
             Box{
                 Point{p.get<0>() - radius, p.get<1>() - radius},


### PR DESCRIPTION
In my project, the most frequent dynamic allocations came from
`std::vector` in `MinDistanceToLineSegment(...)` and they can be
avoided by using a `boost::container::small_vector` which allocates
in the stack when there are fewer than N items. The sizeof items
is only 32 bytes, so having 64 items in `small_vector` uses only
2KB in the stack.